### PR TITLE
Fix occasionally processing global modules with re-exported members on re-index

### DIFF
--- a/src/DeclarationIndex.ts
+++ b/src/DeclarationIndex.ts
@@ -281,8 +281,8 @@ export class DeclarationIndex {
         Object
             .keys(this.parsedResources)
             .forEach((key) => {
-                const resource = this.parsedResources[key] as File;
-                if (this.doesExportResource(resource, resourceToCheck)) {
+                const resource = this.parsedResources[key];
+                if (resource instanceof File && this.doesExportResource(resource, resourceToCheck)) {
                     resources.push(resource.filePath);
                 }
             });

--- a/test/_workspace/declaration-index/specific-cases/reindex-with-global-module-export/classes.ts
+++ b/test/_workspace/declaration-index/specific-cases/reindex-with-global-module-export/classes.ts
@@ -1,0 +1,4 @@
+
+export class MyClass { 
+    public doSomething(): void { }
+}

--- a/test/_workspace/declaration-index/specific-cases/reindex-with-global-module-export/node_modules/@types/some-module/index.d.ts
+++ b/test/_workspace/declaration-index/specific-cases/reindex-with-global-module-export/node_modules/@types/some-module/index.d.ts
@@ -1,0 +1,8 @@
+declare module "inner-module" {
+    export interface SomeInterface { }
+}
+
+declare module "some-module" {
+    import { SomeInterface } from "inner-module";
+    export { SomeInterface } from "inner-module";
+}

--- a/test/declaration-index/specific-cases/reindex-with-global-module/DeclarationIndex.reindex-with-global-module-export.spec.ts
+++ b/test/declaration-index/specific-cases/reindex-with-global-module/DeclarationIndex.reindex-with-global-module-export.spec.ts
@@ -1,0 +1,40 @@
+import { FileChanges } from '../../../../src';
+import { join, resolve } from 'path';
+
+import { DeclarationIndex } from '../../../../src/DeclarationIndex';
+import { TypescriptParser } from '../../../../src/TypescriptParser';
+
+describe('DeclarationIndex - specific case "reindex-with-global-module"', () => {
+
+    const rootPath = resolve(
+        __dirname, '..', '..', '..', '_workspace', 'declaration-index', 'specific-cases',
+        'reindex-with-global-module-export',
+    );
+    const files = [
+        join(rootPath, 'node_modules', '@types', 'some-module', 'index.d.ts'),
+        join(rootPath, 'classes.ts'),
+    ];
+
+    let declarationIndex: DeclarationIndex;
+
+    beforeEach(async () => {
+        declarationIndex = new DeclarationIndex(new TypescriptParser(), rootPath);
+        await declarationIndex.buildIndex(files);
+    });
+
+    it('should parse the declarations', () => {
+        expect(declarationIndex.index['some-module']).toMatchSnapshot();
+        expect(declarationIndex.index['SomeInterface']).toMatchSnapshot();
+        expect(declarationIndex.index['MyClass']).toMatchSnapshot();
+    });
+
+    it(`reindex local file doesn't throw error`, async () => {
+        const changes: FileChanges = {
+            created: [],
+            deleted: [],
+            updated: [files[1]],
+        };
+        await declarationIndex.reindexForChanges(changes);
+    });
+
+});

--- a/test/declaration-index/specific-cases/reindex-with-global-module/__snapshots__/DeclarationIndex.reindex-with-global-module-export.spec.ts.snap
+++ b/test/declaration-index/specific-cases/reindex-with-global-module/__snapshots__/DeclarationIndex.reindex-with-global-module-export.spec.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeclarationIndex - specific case "reindex-with-global-module" should parse the declarations 1`] = `
+Array [
+  DeclarationInfo {
+    "declaration": ModuleDeclaration {
+      "end": 206,
+      "name": "someModule",
+      "start": 74,
+    },
+    "from": "some-module",
+  },
+]
+`;
+
+exports[`DeclarationIndex - specific case "reindex-with-global-module" should parse the declarations 2`] = `
+Array [
+  DeclarationInfo {
+    "declaration": InterfaceDeclaration {
+      "end": 70,
+      "isExported": true,
+      "methods": Array [],
+      "name": "SomeInterface",
+      "properties": Array [],
+      "start": 36,
+    },
+    "from": "some-module",
+  },
+]
+`;
+
+exports[`DeclarationIndex - specific case "reindex-with-global-module" should parse the declarations 3`] = `
+Array [
+  DeclarationInfo {
+    "declaration": ClassDeclaration {
+      "end": 61,
+      "isExported": true,
+      "methods": Array [
+        MethodDeclaration {
+          "end": 59,
+          "isAbstract": false,
+          "name": "doSomething",
+          "parameters": Array [],
+          "start": 29,
+          "type": "void",
+          "variables": Array [],
+          "visibility": 2,
+        },
+      ],
+      "name": "MyClass",
+      "properties": Array [],
+      "start": 1,
+    },
+    "from": "/classes",
+  },
+]
+`;


### PR DESCRIPTION
**Problem**

Instance of Module/Namespace could be passed to ```DeclarationIndex.doesExportResource``` and thus re-index check would fail if module had any re-exported members from any other modules. To easily reproduce - install latest node typings with typescript-hero extension - parser will fail on every re-index. (And break extension experience to anyone who has node typings)

This will make re-indexing to fail:
```ts
declare module "inner-module" {
    export interface SomeInterface { }
}

declare module "some-module" {
    import { SomeInterface } from "inner-module";
    export { SomeInterface } from "inner-module";
}
```

Added simple check to ```instanceof File``` instead of type casting to fix it + test.